### PR TITLE
fix: VBtn - prevent color CSS property overriding

### DIFF
--- a/packages/vuetify/src/components/VBtn/VBtn.sass
+++ b/packages/vuetify/src/components/VBtn/VBtn.sass
@@ -95,7 +95,7 @@
 
       @if ($button-colored-disabled)
         opacity: 1
-        color: rgba(var(--v-theme-on-surface), $button-disabled-opacity)
+        color: rgba(var(--v-theme-on-surface), $button-disabled-opacity) !important
         background: rgb(var(--v-theme-surface))
       @else
         background: rgb(var(--v-theme-surface)) !important


### PR DESCRIPTION
## Description

In this PR I'm adding an `!important` clarification to the `color` css property of the VBtn component.
It is quite common to have both `a` elements and `v-btn` elements in the same project. And sometimes the styling of the `a` elements interfere with the styling of the `v-btn` elements. In the reproduction link below you can see how this happens. 

Adding the `!important` clarification prevents the overriding of the colors of the button. 

The assumption is that the styling of the `v-btn` elements should be managed with the `color` property of the VBtn component. Not by the styling of the anchor tags in the project.

[Reproduction link](https://play.vuetifyjs.com/#eNqlUU1P3DAQ/StTX9JKm1i0SJXSBdFb/0EPhEM2nl0M/pI9G0Cr/e+MnYDCwgGJm2fezHvznq8P4m8IzbhH0Yo1oQ2mJ7zsHMB6rPsQyrMUttdurkpN+Ej1VqNRwKBXaC46YdOuEyCXcxty0JJnsLolCq2UO+93BpvBW1nx9GWf1FqWwRc1rl7lcjEdspaLA7lMQ9SBICHtM6xt8JHgABG3cIRt9BYqdlbl4cG7RMDnwUXGv1f/0BgP/3006lv1I5NPdDM1PZkphp4JB298bHlP/YFjaba3fsQIhwUyA6NOmlB9BPUD6RFfkY3ZY+Fj6SInVmLywOZDc5e840855N1uBlInWiid3GNvue5EzjVxsINyvMY/ocfYOCTpgpVXPCbj3pG2WCtvr341P5vz31LpRMt+g8nWm+gfEkZm6cRqoUN6+/QJrXmSJc6as/NJYu7Vpt+krPGOW7Igh1lHdAojxs96Oll74+sEe+cty3PyR47caHefTtIeUkn6+uXKr5kubJnqJiseV2K6lLWnFXHzDOBnLno=)

The issue is described in #17183.

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://vuetifyjs.com/getting-started/contributing

Provide a general summary of your changes in the title above
Keep the title short and descriptive, as it will be used as a commit message
PR titles should follow conventional-changelog-angular:
https://vuetifyjs.com/getting-started/contributing/#commit-guidelines
-->

<!--
Describe your changes in detail. Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
e.g. resolves #4213 or fixes #2312
-->
